### PR TITLE
Fix/Wheel Picker Center Item Index 계산 수정

### DIFF
--- a/core/admob/src/main/AndroidManifest.xml
+++ b/core/admob/src/main/AndroidManifest.xml
@@ -6,6 +6,9 @@
         <meta-data
             android:name="com.google.android.gms.ads.APPLICATION_ID"
             android:value="${ADMOB_APP_ID}" />
+        <meta-data
+            android:name="com.google.android.gms.ads.flag.NATIVE_AD_DEBUGGER_ENABLED"
+            android:value="false" />
     </application>
 
 </manifest>

--- a/core/admob/src/main/res/layout/small_native_ads_view.xml
+++ b/core/admob/src/main/res/layout/small_native_ads_view.xml
@@ -30,8 +30,10 @@
             android:background="@color/core_admob_yellow"
             android:text="@string/core_admob_ad"
             android:textColor="@color/core_admob_text"
+            android:textSize="12dp"
             app:layout_constraintStart_toStartOf="@+id/adMedia"
-            app:layout_constraintTop_toTopOf="@id/adMedia" />
+            app:layout_constraintTop_toTopOf="@id/adMedia"
+            tools:ignore="SpUsage" />
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/actionLayout"
@@ -63,12 +65,13 @@
                 android:ellipsize="end"
                 android:maxLines="3"
                 android:text=""
-                android:textSize="14sp"
+                android:textSize="12dp"
                 android:textStyle="bold"
                 app:layout_constraintBottom_toTopOf="@id/adStars"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toEndOf="@id/adAppIcon"
-                app:layout_constraintTop_toTopOf="parent" />
+                app:layout_constraintTop_toTopOf="parent"
+                tools:ignore="SpUsage" />
 
             <RatingBar
                 android:id="@+id/adStars"
@@ -89,8 +92,9 @@
                 android:backgroundTint="@color/core_admob_primary"
                 android:gravity="center"
                 android:text=""
-                android:textSize="12sp"
-                app:layout_constraintBottom_toBottomOf="parent" />
+                android:textSize="12dp"
+                app:layout_constraintBottom_toBottomOf="parent"
+                tools:ignore="SpUsage" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/feature/alarm/src/main/java/com/oldogz/applinkalarm/feature/alarm/component/WheelPicker.kt
+++ b/feature/alarm/src/main/java/com/oldogz/applinkalarm/feature/alarm/component/WheelPicker.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.oldogz.core.designsystem.theme.AppLinkAlarmTheme
+import kotlin.math.abs
 
 @Composable
 internal fun <T> WheelPicker(
@@ -34,10 +35,23 @@ internal fun <T> WheelPicker(
     selectedItem: (T?) -> Unit,
 ) {
     val flingBehavior = rememberSnapFlingBehavior(lazyListState = state)
-    val firstVisibleItemIndex by remember { derivedStateOf { state.firstVisibleItemIndex } }
+    val centerItemIndex by remember {
+        derivedStateOf {
+            val layoutInfo = state.layoutInfo
+            val viewportHeight = layoutInfo.viewportSize.height
+            val centerY = viewportHeight / 2
 
-    LaunchedEffect(firstVisibleItemIndex) {
-        selectedItem(list.getOrNull(firstVisibleItemIndex))
+            val centerIndex = layoutInfo.visibleItemsInfo.minByOrNull { item ->
+                val itemCenter = item.offset + item.size / 2
+                abs(itemCenter - centerY)
+            }?.index ?: state.firstVisibleItemIndex
+
+            centerIndex - 1
+        }
+    }
+
+    LaunchedEffect(centerItemIndex) {
+        selectedItem(list.getOrNull(centerItemIndex))
     }
 
     LazyColumn(
@@ -58,7 +72,7 @@ internal fun <T> WheelPicker(
             ) {
                 Text(
                     text = item.toString(),
-                    style = if (i == firstVisibleItemIndex) {
+                    style = if (i == centerItemIndex) {
                         MaterialTheme.typography.headlineSmall.copy(
                             fontWeight = FontWeight.Bold,
                             color = MaterialTheme.colorScheme.onBackground

--- a/feature/main/src/main/java/com/oldogz/applinkalarm/feature/main/MainActivity.kt
+++ b/feature/main/src/main/java/com/oldogz/applinkalarm/feature/main/MainActivity.kt
@@ -5,6 +5,8 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Density
 import com.oldogz.core.admob.AdMobManager
 import com.oldogz.core.admob.LocalAdMobManager
 import com.oldogz.core.designsystem.theme.AppLinkAlarmTheme
@@ -31,7 +33,8 @@ class MainActivity : ComponentActivity() {
             AppLinkAlarmTheme {
                 CompositionLocalProvider(
                     LocalAdMobManager provides adMobManager,
-                    LocalFirebaseManager provides firebaseManager
+                    LocalFirebaseManager provides firebaseManager,
+                    LocalDensity provides Density(LocalDensity.current.density, 0.8f),
                 ) {
                     MainScreen(
                         navigator = navigator,


### PR DESCRIPTION
## 개요
### Wheel Picker Center Item Index 계산 수정
- 기존의 Wheel Picker는 LazyListState의 firstVisibleItemIndex를 통해서 계산되었음.
- LazyColumn의 사이즈를 Item * 3으로 설정하여 최대 3개까지 보이도록 하며, firstVisibleItemIndex을 사용하여 Center Item Index를 계산했지만, 일부 기기(Galaxy S22+)에서 Item이 3개 이상 보이면서 firstVisibleItemIndex가 예상대로 동작하지 않는 것을 확인.
- layoutInfo의 visibleItemsInfo들 중, 가장 중앙에 가까운 아이템을 계산하고 해당 아이템 Index를 통해 Center Item Index를 계산하는 방식으로 개선

### 디바이스의 글자 크기 설정에 따른 UI 짤림 현상
- 디바이스 글자 크기 설정에 따라 일부 UI가 짤리는 문제 발생, 현재는 MainScreen에서 Density의 고정값을 주도록 설정
- 이 후에 짤리지 않는 UI의 경우는 디바이스에서 설정한 글자 크기로 적용되도록 변경 필요.
- Native Ads의 경우 사용자 디바이스의 글자 크기에 따라 광고 정책에 위반 될 수 있기 때문에, sp -> dp 로 고정하였음.