### PR TITLE
Fix/알람 재등록 예외 수정

### DIFF
--- a/core/alarm/src/main/java/com/oldogz/core/alarm/manager/AppLinkAlarmScheduleManager.kt
+++ b/core/alarm/src/main/java/com/oldogz/core/alarm/manager/AppLinkAlarmScheduleManager.kt
@@ -30,10 +30,10 @@ class AppLinkAlarmScheduleManager @Inject constructor(
         }
     }
 
-    fun scheduleAlarm(alarm: AppLinkAlarm) {
+    fun scheduleAlarm(alarm: AppLinkAlarm, isRescheduling: Boolean = false) {
         if (!alarm.active || alarm.dayOfWeek.isEmpty()) return
 
-        val nextAlarmTime = calculateNextAlarmTime(alarm)
+        val nextAlarmTime = calculateNextAlarmTime(alarm, isRescheduling)
 
         val pendingIntent =
             createPendingIntent(alarm.id, alarm.alarmMode.name, alarm.linkedAppPackage)
@@ -49,10 +49,13 @@ class AppLinkAlarmScheduleManager @Inject constructor(
         alarmManager.cancel(createPendingIntent(alarmId, alarmMode, linkedAppPackage))
     }
 
-    private fun calculateNextAlarmTime(alarm: AppLinkAlarm): Long {
+    private fun calculateNextAlarmTime(alarm: AppLinkAlarm, isRescheduling: Boolean): Long {
+        val marginMs = if (isRescheduling) 2000L else 0L
+        val now = System.currentTimeMillis() + marginMs
+
         val calendar = Calendar.getInstance().apply {
             timeZone = TimeZone.getDefault()
-            timeInMillis = System.currentTimeMillis()
+            timeInMillis = now
 
             val hour24 = (alarm.hour % 12) + if (alarm.periodOfDay == PeriodOfDay.PM) 12 else 0
 
@@ -64,10 +67,11 @@ class AppLinkAlarmScheduleManager @Inject constructor(
 
         val todayDayOfWeek = Calendar.getInstance().get(Calendar.DAY_OF_WEEK)
         val nextDayOfWeek =
-            findNextDayOfWeek(alarm.dayOfWeek, todayDayOfWeek, calendar.timeInMillis)
+            findNextDayOfWeek(alarm.dayOfWeek, todayDayOfWeek, calendar.timeInMillis, now)
         calendar.set(Calendar.DAY_OF_WEEK, nextDayOfWeek)
 
-        if (calendar.timeInMillis <= System.currentTimeMillis()) {
+
+        if (calendar.timeInMillis <= now) {
             calendar.add(Calendar.WEEK_OF_YEAR, 1)
         }
 
@@ -77,11 +81,12 @@ class AppLinkAlarmScheduleManager @Inject constructor(
     private fun findNextDayOfWeek(
         dayOfWeekList: List<DayOfWeek>,
         todayDayOfWeek: Int,
-        alarmTime: Long
+        alarmTime: Long,
+        now: Long,
     ): Int {
         val sortedDayOfWeek = dayOfWeekList.map { it.value }.sorted()
         val dayOfWeek = sortedDayOfWeek.find {
-            it > todayDayOfWeek || (it == todayDayOfWeek && alarmTime > System.currentTimeMillis())
+            it > todayDayOfWeek || (it == todayDayOfWeek && alarmTime > now)
         }
         return dayOfWeek ?: sortedDayOfWeek.first()
     }

--- a/core/alarm/src/main/java/com/oldogz/core/alarm/worker/RescheduleAlarmWorker.kt
+++ b/core/alarm/src/main/java/com/oldogz/core/alarm/worker/RescheduleAlarmWorker.kt
@@ -33,7 +33,7 @@ class RescheduleAlarmWorker @AssistedInject constructor(
                 tags.contains(RESCHEDULE_ALARM_TAG) -> {
                     val alarmId = inputData.getInt(RESCHEDULE_ALARM_DATA_ID, -1)
                     val appLinkAlarm = appLinkAlarmRepository.getAlarmById(alarmId).first()
-                    appLinkAlarmScheduleManager.scheduleAlarm(appLinkAlarm)
+                    appLinkAlarmScheduleManager.scheduleAlarm(appLinkAlarm, true)
                 }
             }
             Result.success()

--- a/feature/main/src/main/AndroidManifest.xml
+++ b/feature/main/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <application android:hardwareAccelerated="true">
         <activity
@@ -21,6 +22,12 @@
                 <data android:host="feature" />
             </intent-filter>
         </activity>
+
+        <activity
+            android:name="com.google.android.gms.ads.AdActivity"
+            android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|uiMode|screenSize|smallestScreenSize"
+            android:theme="@style/AdInspectorActivityTheme"
+            tools:replace="android:theme" />
     </application>
 
 </manifest>

--- a/feature/main/src/main/res/values-v35/themes.xml
+++ b/feature/main/src/main/res/values-v35/themes.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools">
+
+    <style name="AdInspectorActivityTheme" parent="@android:style/Theme.Translucent" tools:ignore="ResourceName">
+        <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
+    </style>
+</resources>


### PR DESCRIPTION
## 개요
- 특정 시간에 등록된 알림이 예정보다 미세하게 빠르게 울리는 오류 해결
- 미세하게 빠르게 도착한 알람이 바로 재등록 로직을 수행하면서 다시 특정 시간에 알림이 울리며 중복된 알람이 발생
- 알림만 모드에서는 2번의 알림이 도착, 기본 알람 모드의 경우 알람이 울리는 도중 새로운 알람이 울려 놓친 알람으로 처리됨.
- 알람 재등록 시 2초 정도의 마진을 두고 현재 시간을 계산하여 재등록하도록 변경
- AdActivity의 edgeToEdge를 비활성화하여 targetSdk 35의 Admob 전면광고 문제 임시 해결
- 임시적으로 windowOptOutEdgeToEdgeEnforcement 적용하여 EdgeToEdge 비활성화
- TargetSdk 36부터는 windowOptOutEdgeToEdgeEnforcement를 사용할 수 없으므로 주의
- Admob에서는 9월 중으로 EdgeToEdge에 대응 업데이트 할 예정이라고 함.

## 관련 이슈
- https://groups.google.com/g/google-admob-ads-sdk/c/WyGsRV--EoE