### PR TITLE
fix: billingClient 준비 상태 확인 처리

### DIFF
--- a/core/billing/src/main/java/com/oldogz/core/billing/SubscriptionManagerImpl.kt
+++ b/core/billing/src/main/java/com/oldogz/core/billing/SubscriptionManagerImpl.kt
@@ -25,7 +25,7 @@ import kotlinx.coroutines.flow.update
 import javax.inject.Inject
 
 class SubscriptionManagerImpl @Inject constructor(
-    @ApplicationContext context: Context
+    @ApplicationContext private val context: Context
 ) : SubscriptionManager {
 
     private val _availableProducts = MutableStateFlow<List<Product>>(emptyList())
@@ -72,6 +72,7 @@ class SubscriptionManagerImpl @Inject constructor(
     private var billingClient: BillingClient = BillingClient.newBuilder(context)
         .setListener(purchasesUpdatedListener)
         .enablePendingPurchases(pendingPurchasesParams)
+        .enableAutoServiceReconnection()
         .build()
 
     override fun initialize(onSetupFinished: () -> Unit) {
@@ -149,16 +150,26 @@ class SubscriptionManagerImpl @Inject constructor(
         productDetails: ProductDetails,
         offerToken: String
     ) {
-        val productDetailsParams = BillingFlowParams.ProductDetailsParams.newBuilder()
-            .setProductDetails(productDetails)
-            .setOfferToken(offerToken)
-            .build()
+        println("billingClient.isReady: ${billingClient.isReady}")
+        if (billingClient.isReady) {
+            val productDetailsParams = BillingFlowParams.ProductDetailsParams.newBuilder()
+                .setProductDetails(productDetails)
+                .setOfferToken(offerToken)
+                .build()
 
-        val billingFlowParams = BillingFlowParams.newBuilder()
-            .setProductDetailsParamsList(listOf(productDetailsParams))
-            .build()
+            val billingFlowParams = BillingFlowParams.newBuilder()
+                .setProductDetailsParamsList(listOf(productDetailsParams))
+                .build()
 
-        billingClient.launchBillingFlow(activity, billingFlowParams)
+            billingClient.launchBillingFlow(activity, billingFlowParams)
+        } else {
+            Log.e(TAG, "Billing client is not ready")
+            Toast.makeText(
+                context,
+                context.getString(R.string.core_billing_text_connection_error),
+                Toast.LENGTH_SHORT
+            ).show()
+        }
     }
 
     override fun queryPurchases(

--- a/core/billing/src/main/res/values-es/strings.xml
+++ b/core/billing/src/main/res/values-es/strings.xml
@@ -1,4 +1,5 @@
 <resources>
     <string name="core_billing_text_payment_canceled">Pago cancelado</string>
     <string name="core_billing_text_payment_error">Ocurrió un error durante el pago (%1$d)</string>
+    <string name="core_billing_text_connection_error">No se pudo conectar con el servicio de pago. Por favor, reinicia la aplicación.</string>
 </resources>

--- a/core/billing/src/main/res/values-fr/strings.xml
+++ b/core/billing/src/main/res/values-fr/strings.xml
@@ -1,4 +1,5 @@
 <resources>
     <string name="core_billing_text_payment_canceled">Paiement annulé</string>
     <string name="core_billing_text_payment_error">Une erreur est survenue lors du paiement (%1$d)</string>
+    <string name="core_billing_text_connection_error">Impossible de se connecter au service de paiement. Veuillez redémarrer l\'application</string>
 </resources>

--- a/core/billing/src/main/res/values-in/strings.xml
+++ b/core/billing/src/main/res/values-in/strings.xml
@@ -1,4 +1,5 @@
 <resources>
     <string name="core_billing_text_payment_canceled">Pembayaran dibatalkan</string>
     <string name="core_billing_text_payment_error">Terjadi kesalahan saat pembayaran (%1$d)</string>
+    <string name="core_billing_text_connection_error">Tidak dapat terhubung ke layanan pembayaran. Harap mulai ulang aplikasi.</string>
 </resources>

--- a/core/billing/src/main/res/values-ja/strings.xml
+++ b/core/billing/src/main/res/values-ja/strings.xml
@@ -1,4 +1,5 @@
 <resources>
     <string name="core_billing_text_payment_canceled">支払いがキャンセルされました</string>
     <string name="core_billing_text_payment_error">支払い中にエラーが発生しました（%1$d）</string>
+    <string name="core_billing_text_connection_error">決済サービスに接続できませんでした。アプリを再起動してください。</string>
 </resources>

--- a/core/billing/src/main/res/values-ko/strings.xml
+++ b/core/billing/src/main/res/values-ko/strings.xml
@@ -1,4 +1,5 @@
 <resources>
     <string name="core_billing_text_payment_canceled">결제가 취소되었습니다</string>
     <string name="core_billing_text_payment_error">결제 중 오류가 발생했습니다(%1$d)</string>
+    <string name="core_billing_text_connection_error">결제 서비스에 연결할 수 없습니다. 앱을 재시작 해주세요.</string>
 </resources>

--- a/core/billing/src/main/res/values-zh-rCN/strings.xml
+++ b/core/billing/src/main/res/values-zh-rCN/strings.xml
@@ -1,4 +1,5 @@
 <resources>
     <string name="core_billing_text_payment_canceled">支付已取消</string>
     <string name="core_billing_text_payment_error">支付过程中发生错误（%1$d）</string>
+    <string name="core_billing_text_connection_error">无法连接到支付服务。请重启应用。</string>
 </resources>

--- a/core/billing/src/main/res/values-zh-rTW/strings.xml
+++ b/core/billing/src/main/res/values-zh-rTW/strings.xml
@@ -1,4 +1,5 @@
 <resources>
     <string name="core_billing_text_payment_canceled">付款已取消</string>
     <string name="core_billing_text_payment_error">付款時發生錯誤（%1$d）</string>
+    <string name="core_billing_text_connection_error">無法連接到支付服務。請重新啟動應用程式。</string>
 </resources>

--- a/core/billing/src/main/res/values/strings.xml
+++ b/core/billing/src/main/res/values/strings.xml
@@ -1,4 +1,5 @@
 <resources>
     <string name="core_billing_text_payment_canceled">Payment canceled</string>
     <string name="core_billing_text_payment_error">An error occurred during payment(%1$d)</string>
+    <string name="core_billing_text_connection_error">Could not connect to the payment service. Please restart the app.</string>
 </resources>


### PR DESCRIPTION
## 개요
- billingClient가 준비 완료가 아닌 상태에서 PurchaseFlow를 실행할 때 발생할 수 있는 오류 해결
- enableAutoServiceReconnection 옵션 추가