### PR TITLE
Fix/notification 연속 동작 오류 수정 및 UI 최적화

### DIFF
--- a/core/alarm/src/main/java/com/oldogz/core/alarm/manager/AppLinkAlarmNotificationManager.kt
+++ b/core/alarm/src/main/java/com/oldogz/core/alarm/manager/AppLinkAlarmNotificationManager.kt
@@ -92,7 +92,7 @@ class AppLinkAlarmNotificationManager @Inject constructor(
             context,
             appLinkAlarm.id,
             alarmStopIntent,
-            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_CANCEL_CURRENT
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
         )
 
         val pendingIntent = createDefaultPendingIntent(appLinkAlarm, "home")
@@ -181,7 +181,7 @@ class AppLinkAlarmNotificationManager @Inject constructor(
             context,
             appLinkAlarm.id,
             alarmSkipIntent,
-            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_CANCEL_CURRENT
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
         )
 
         val hourText = appLinkAlarm.hour.toString().padStart(2, '0')
@@ -245,7 +245,7 @@ class AppLinkAlarmNotificationManager @Inject constructor(
             addNextIntentWithParentStack(intent)
             getPendingIntent(
                 appLinkAlarm.id,
-                PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_CANCEL_CURRENT
+                PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
             )
         }
     }
@@ -259,7 +259,7 @@ class AppLinkAlarmNotificationManager @Inject constructor(
                     context,
                     appLinkAlarm.id,
                     intent,
-                    PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_CANCEL_CURRENT
+                    PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
                 )
             }
 
@@ -270,7 +270,7 @@ class AppLinkAlarmNotificationManager @Inject constructor(
                     context,
                     appLinkAlarm.id,
                     intent,
-                    PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_CANCEL_CURRENT
+                    PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
                 )
             }
         }

--- a/core/alarm/src/main/java/com/oldogz/core/alarm/service/AppLinkAlarmPlayingService.kt
+++ b/core/alarm/src/main/java/com/oldogz/core/alarm/service/AppLinkAlarmPlayingService.kt
@@ -122,6 +122,7 @@ class AppLinkAlarmPlayingService : Service() {
 
 
     private suspend fun playAppLinkAlarm(appLinkAlarm: AppLinkAlarm, includeAds: Boolean) {
+        appLinkAlarmNotificationManager.cancel(appLinkAlarm.id)
         startForeground(
             appLinkAlarm.id,
             appLinkAlarmNotificationManager.createNotification(appLinkAlarm, includeAds)

--- a/core/designsystem/src/main/java/com/oldogz/core/designsystem/component/AppLinkAlarmAsyncImage.kt
+++ b/core/designsystem/src/main/java/com/oldogz/core/designsystem/component/AppLinkAlarmAsyncImage.kt
@@ -1,7 +1,6 @@
 package com.oldogz.core.designsystem.component
 
 import android.content.res.Configuration
-import android.graphics.drawable.Drawable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -10,21 +9,31 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.painter.ColorPainter
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.core.graphics.drawable.toDrawable
 import coil.compose.AsyncImage
 import com.oldogz.core.designsystem.theme.AppLinkAlarmTheme
 
 @Composable
 fun AppLinkAlarmAsyncImage(
     modifier: Modifier = Modifier,
-    drawable: Drawable?,
+    packageName: String,
     contentDescription: String?
 ) {
+    val context = LocalContext.current
+    val packageManager = context.packageManager
+
+    val appInfo = try {
+        packageManager.getApplicationInfo(packageName, 0)
+    } catch (e: Exception) {
+        null
+    }
+    val icon = appInfo?.loadIcon(packageManager)
+
     AsyncImage(
         modifier = modifier,
-        model = drawable,
+        model = icon,
         contentDescription = contentDescription,
         placeholder = ColorPainter(MaterialTheme.colorScheme.secondary),
         error = ColorPainter(MaterialTheme.colorScheme.secondary),
@@ -41,7 +50,7 @@ private fun AppLinkAlarmAsyncImagePreview() {
                 modifier = Modifier
                     .size(48.dp)
                     .clip(RoundedCornerShape(8.dp)),
-                drawable = (1).toDrawable(),
+                packageName = "",
                 contentDescription = ""
             )
         }

--- a/feature/alarm/src/main/java/com/oldogz/applinkalarm/feature/alarm/component/AppIconImage.kt
+++ b/feature/alarm/src/main/java/com/oldogz/applinkalarm/feature/alarm/component/AppIconImage.kt
@@ -8,9 +8,10 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -37,13 +38,12 @@ internal fun AppIconImage(
             val label =
                 appInfo?.loadLabel(packageManager)
                     ?: stringResource(R.string.feature_alarm_text_not_found)
-            val icon = appInfo?.loadIcon(packageManager)
 
             AppLinkAlarmAsyncImage(
                 modifier = Modifier
                     .size(size)
                     .clip(RoundedCornerShape(8.dp)),
-                drawable = icon,
+                packageName = target.packageName,
                 contentDescription = stringResource(
                     R.string.feature_alarm_icon_description_app_icon,
                     label
@@ -56,12 +56,11 @@ internal fun AppIconImage(
                 modifier = Modifier
                     .size(size)
                     .clip(RoundedCornerShape(8.dp)),
-                painter = painterResource(R.drawable.outline_link_24),
+                imageVector = ImageVector.vectorResource(R.drawable.outline_link_24),
                 contentDescription = "URL"
             )
         }
     }
-
 }
 
 @Composable

--- a/feature/alarm/src/main/java/com/oldogz/applinkalarm/feature/alarm/edit/AppSelectDialog.kt
+++ b/feature/alarm/src/main/java/com/oldogz/applinkalarm/feature/alarm/edit/AppSelectDialog.kt
@@ -35,18 +35,18 @@ import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
-import androidx.core.graphics.drawable.toDrawable
 import com.oldogz.applinkalarm.feature.alarm.R
 import com.oldogz.applinkalarm.feature.alarm.model.AppInfo
 import com.oldogz.core.designsystem.component.AppLinkAlarmAsyncImage
@@ -82,7 +82,6 @@ fun AppSelectDialog(
                 AppInfo(
                     appName = app.loadLabel(packageManager).toString(),
                     packageName = app.packageName,
-                    icon = app.loadIcon(packageManager)
                 )
             }.distinctBy { it.packageName }
             apps.addAll(appInfoList)
@@ -192,7 +191,7 @@ internal fun AddUrlItem(
             modifier = Modifier
                 .size(48.dp)
                 .clip(RoundedCornerShape(8.dp)),
-            painter = painterResource(R.drawable.outline_link_24),
+            imageVector = ImageVector.vectorResource(R.drawable.outline_link_24),
             contentDescription = stringResource(R.string.feature_alarm_text_add_url),
         )
         Column(
@@ -246,7 +245,7 @@ internal fun AppInfoItem(
             modifier = Modifier
                 .size(48.dp)
                 .clip(RoundedCornerShape(8.dp)),
-            drawable = appInfo.icon,
+            packageName = appInfo.packageName,
             contentDescription = stringResource(
                 R.string.feature_alarm_icon_description_app_icon,
                 appInfo.appName
@@ -315,7 +314,6 @@ private fun AppInfoItemPreview() {
             appInfo = AppInfo(
                 appName = "앱 이름",
                 packageName = "com.dev.oldogz",
-                icon = (1).toDrawable(),
             ),
             onClick = {}
         )

--- a/feature/alarm/src/main/java/com/oldogz/applinkalarm/feature/alarm/model/AppInfo.kt
+++ b/feature/alarm/src/main/java/com/oldogz/applinkalarm/feature/alarm/model/AppInfo.kt
@@ -1,9 +1,6 @@
 package com.oldogz.applinkalarm.feature.alarm.model
 
-import android.graphics.drawable.Drawable
-
 data class AppInfo(
     val appName: String,
     val packageName: String,
-    val icon: Drawable
 )


### PR DESCRIPTION
## 개요
- 3개 이상의 Notification Only 타입의 알람이 동시 도착할 경우, billingClient 초기화와 프로세스 재시작 등에 의한 PendingIntent 재호출 발생
  - FLAG_CANCEL_CURRENT 설정으로 인해 기존 PendingIntent 취소 및 Notification 미동작 발생
  - FLAG_UPDATE_CURRENT 설정으로 변경. 재호출 되더라도 최신 PendingIntent 유지
- AlarmHomeScreen에서 알람 Active 상태를 변경하였을 때, 다른 Alarm의 아이콘이 깜빡이며 recomposition 되는 현상 수정
  - AppLinkAlarmAsyncImage에 전달되는 Drawable로 인해 recomposition 발생.
  - packageName: String을 전달하는 것으로 수정 및 skip 가능하도록 변경.